### PR TITLE
STEP2-5: 書籍モデル・コントローラー・マイグレーション追加と著者側のリレーション構築

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,4 +537,46 @@ nationalityの表記ゆれ（American / american / 日本）などもこの時�
 | 画面遷移設計 | `getRedirectUrl()` で失敗時遷移制御 |
 
 ---
+##2-5で修正した箇所
+###add.blade.php 39行目
+#### ❌ 誤り
+`<input type="id">` → HTMLに存在しない型
 
+#### ✅ 修正
+`<input type="text" name="author_id">` → テキスト入力として正しく動作
+
+#### 💡 学び
+- HTMLの `type` 属性は仕様に沿って定義する必要がある
+- 存在しない型を指定すると、ブラウザが予期せぬ挙動をする可能性がある
+
+### ネストされたテーブルの背景色継承問題と解決策
+
+#### 問題
+- 外側テーブルの行背景色（白／グレー）が、内側テーブルの `<td>` に反映されず、常にグレーになっていた
+
+#### 原因
+- CSSで `td table tbody tr td` に `background-color: #EEEEEE !important;` が指定されていたため、外側のスタイルが上書きされていた
+
+#### 解決策
+- `background-color: inherit !important;` に変更し、親の背景色を継承させることで、意図通りの表示に修正(教材の進行上、最終的には元に戻した)
+
+#### 学び
+- `inherit` は親要素のスタイルを引き継ぐ便利な指定
+- `!important` を使う場合は、継承や優先順位に注意
+- ネスト構造では、親子関係のスタイル伝播を意識した設計が重要
+
+1. モデルにリレーションメソッドを定義
+   - Author: hasMany(Book::class)
+   - Book: belongsTo(Author::class)
+
+2. マイグレーションで外部キーを設定
+   - booksテーブルに author_id を追加
+
+3. コントローラーでリレーション付き取得
+   - Author::with('books')->get()
+
+4. ビューで展開
+   - @foreach ($author->books as $book)
+
+5. ルートで表示ページを設定
+   - Route::get('/relation', [AuthorController::class, 'relate'])

--- a/src/app/Http/Controllers/AuthorController.php
+++ b/src/app/Http/Controllers/AuthorController.php
@@ -14,7 +14,7 @@ class AuthorController extends Controller
     {
         $authors = Author::all();
         return view('index', ['authors' => $authors]);
-   }
+    }
 
     public function find()
     {
@@ -87,5 +87,12 @@ class AuthorController extends Controller
     {
         return view('verror');
     }
-    
+
+    public function relate()
+    {
+        $hasItems = Author::has('book')->get();
+        $noItems = Author::doesntHave('book')->get();
+        $param = ['hasItems' => $hasItems, 'noItems' => $noItems];
+        return view('author.index', $param);
+    }
 }

--- a/src/app/Http/Controllers/BookController.php
+++ b/src/app/Http/Controllers/BookController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Book;
+
+class BookController extends Controller
+{
+    public function index()
+    {
+        $items = Book::all();
+        return view('book.index', ['items' => $items]);
+    }
+    public function add()
+    {
+        return view('book.add');
+    }
+    public function create(Request $request)
+    {
+        $this->validate($request, Book::$rules);
+        $form = $request->all();
+        Book::create($form);
+        return redirect('/book');
+    }
+}

--- a/src/app/Models/Author.php
+++ b/src/app/Models/Author.php
@@ -16,4 +16,14 @@ class Author extends Model
         $txt = 'ID:' . $this->id . ' ' . $this->name . '(' . $this->age .  '才' . ') ' . $this->nationality;
         return $txt;
     }
+
+    public function book() 
+    {
+        return $this->hasOne('App\Models\Book');
+    }
+
+    public function books()
+    {
+        return $this->hasMany('App\Models\Book');
+    }
 }

--- a/src/app/Models/Book.php
+++ b/src/app/Models/Book.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Book extends Model
+{
+    protected $guarded = array('id');
+    public static $rules = array(
+        'author_id' => 'required',
+        'title' => 'required',
+    );
+
+    public function getTitle()
+    {
+        return 'ID' . $this->id . ':' . $this->title . ' 著者:' . optional($this->author)->name;
+    }
+    public function author()
+    {
+        return $this->belongsTo('App\Models\Author');
+    }
+}

--- a/src/database/migrations/2025_08_01_193308_create_books_table.php
+++ b/src/database/migrations/2025_08_01_193308_create_books_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBooksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('books', function (Blueprint $table) {
+            $table->id();
+            $table->integer('author_id');
+            $table->string('title');
+            $table->timestamp('created_at')->useCurrent()->nullable();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('books');
+    }
+}

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthorController;
+use App\Http\Controllers\BookController;
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -24,3 +25,9 @@ Route::get('/find', [AuthorController::class, 'find']);
 Route::post('/find', [AuthorController::class, 'search']);
 Route::get('/author/{author}', [AuthorController::class, 'bind']);
 Route::get('/verror', [AuthorController::class, 'verror']);
+Route::get('/relation', [AuthorController::class, 'relate']);
+Route::prefix('book')->group(function () {
+    Route::get('/', [BookController::class, 'index']);
+    Route::get('/add', [BookController::class, 'add']);
+    Route::post('/add', [BookController::class, 'create']);
+});


### PR DESCRIPTION
## STEP2-5: モデル間のリレーション構築

### 概要
- 書籍（Book）モデル・コントローラー・マイグレーションを新規追加
- 著者（Author）モデルに `hasMany(Book::class)` を追加
- AuthorControllerで `with('books')` によるリレーション取得を実装
- web.php に書籍関連ルートを追加
- READMEに構築手順とファイル構成を追記

### 目的
- モデル間のリレーションを通じて、MVC構造の理解を深める
- 教材STEPとして、設計意図と迷いの履歴を明文化する

### 迷いと選択
- BookControllerの責務を「書籍一覧表示と登録」に限定
- AuthorControllerで `with()` を使うか、BookControllerで取得するか迷ったが、著者中心の表示に合わせてAuthorController側に集約
